### PR TITLE
Small fixes

### DIFF
--- a/GERMLINE_0001.cpp
+++ b/GERMLINE_0001.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
 	string params = argv[0];
 
 	bool bad_param = false;
-	for(int i=1;i<argc;i++){
+	for (int i = 1; i < argc; i++) {
 		params += " " + string(argv[i]);
 		if( strncmp(argv[i], "-min_m", strlen("-min_m")) == 0 && i < argc-1)				MIN_MATCH_LEN = atof(argv[++i]);
 		else if( strncmp(argv[i], "-err_hom", strlen("-max_err")) == 0 && i < argc-1)		{ MAX_ERR_HOM = atoi(argv[++i]); }
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 		cerr << "ERROR: cannot execute with both -haploid and -homoz/-homoz-only flags active" << endl << endl;
 		bad_param = true;
 	}
-	
+
 	if(bad_param)
 	{
 		cerr << "usage: " << argv[0] << "<flags (optional)> -input [ped file] [map file] -output [out file]" << endl
@@ -86,14 +86,14 @@ int main(int argc, char* argv[])
 		<< '\t' << "-to_snp" << '\t' << "End SNP (rsID)." << endl
 		<< '\t' << "-haps" << '\t' << "Print the resolved haplotypes in a seperate HAPS file." << endl
 		<< '\t' << "-map [file]" << '\t' << "Genetic distance map in PLINK map format." << endl
-		<< '\t' << "-distrib [file]" << '\t' << "Only print the distribution of segment lengths, using breaks listed in file." << endl		
+		<< '\t' << "-distrib [file]" << '\t' << "Only print the distribution of segment lengths, using breaks listed in file." << endl
 		<< '\t' << "-bits" << '\t' << "Slice size." << endl
 		<< '\t' << "-homoz" << '\t' << "Allow self matches (homozygosity)" << endl
 		<< '\t' << "-homoz-only" << '\t' << "Look for autozygous/homozygous segments only, does not detect IBD" << endl
 		<< '\t' << "-haploid" << '\t' << "Treat input individual as two fully phased chromosomes with no recombination\n\t\toutput IDs with 0/1 suffix for chromosome destinction" << endl
 		<< '\t' << "-h_extend" << '\t' << "Extend from seeds if *haplotypes* match" << endl
 		<< '\t' << "-w_extend" << '\t' << "Extend, one marker at a time, beyong the boundaries of a found match" << endl;
-		return 0;
+		return 1;
 	}
 
 	if( rs_range[0] != "" && rs_range[1] != "" )
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 	{
 		ALL_SNPS.loadGeneticDistanceMap( map );
 	}
-	
+
 	if(DISTRIB_OUT) {
 		// load the histogram
        	ifstream s_map( hist.c_str() );
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 
 	GERMLINE germline;
     germline.mine( params );
-    return 1;
+    return 0;
 }
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,28 @@
-CC=	g++
-OPT=	-O3 -I include
-SRCS=	GERMLINE_0001.cpp GERMLINE.cpp Share.cpp Chromosome.cpp ChromosomePair.cpp HMIndividualsExtractor.cpp MarkerSet.cpp Individual.cpp Individuals.cpp InputManager.cpp MatchFactory.cpp MatchesBuilder.cpp NucleotideMap.cpp PEDIndividualsExtractor.cpp Match.cpp PolymorphicIndividualsExtractor.cpp SNP.cpp SNPPositionMap.cpp SNPs.cpp
-OBJS=	GERMLINE_0001.o GERMLINE.o Chromosome.o Share.o ChromosomePair.o HMIndividualsExtractor.o MarkerSet.o Individual.o Individuals.o InputManager.o MatchFactory.o MatchesBuilder.o NucleotideMap.o PEDIndividualsExtractor.o Match.o PolymorphicIndividualsExtractor.o SNP.o SNPPositionMap.o SNPs.o
-MAIN=	germline
-BMATCH=	parse_bmatch
+CXX = g++
+INCLUDES = include
+CXXFLAGS = -O3 -Wall -I $(INCLUDES)
+OBJECTS = GERMLINE_0001.o GERMLINE.o Chromosome.o Share.o ChromosomePair.o HMIndividualsExtractor.o MarkerSet.o Individual.o Individuals.o InputManager.o MatchFactory.o MatchesBuilder.o NucleotideMap.o PEDIndividualsExtractor.o Match.o PolymorphicIndividualsExtractor.o SNP.o SNPPositionMap.o SNPs.o
 
-all: clean germline bmatch test
+.PHONY: all
+all: germline bmatch impute_to_ped test
 
 bmatch:
-	$(CC) $(BMATCH).cpp -o $(BMATCH)
+	$(CXX) parse_bmatch.cpp -o parse_bmatch
 
-$(OBJS): $(SRCS)
-	$(CC) $(OPT) -c $*.cpp
+germline: $(OBJECTS)
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
-germline: $(OBJS)
-	$(CC) $(OPT) -o $(MAIN) $(OBJS)
+impute_to_ped:
+	$(CXX) impute_to_ped.cpp -o bin/impute_to_ped
 
-clean:
-	-rm -f *.o $(MAIN) $(BMATCH) test/generated.match test/generated.log test/generated.err test/generated.out
 test: test_plink
 
 test_plink:
 	-@rm -f test/generated.match test/generated.log test/generated.err test/generated.out
-	-@./$(MAIN) -silent -bits 50 -min_m 1 -err_hom 2 -err_het 0 < test/test.run > test/generated.out 2> test/generated.err | echo -e "---\nRunning Test Case\n---"
+	-@./germline -silent -bits 50 -min_m 1 -err_hom 2 -err_het 0 < test/test.run > test/generated.out 2> test/generated.err | echo -e "---\nRunning Test Case\n---"
 	diff -q -s test/expected.match test/generated.match
+
+.PHONY: clean
+clean:
+	-rm -f *.o germline parse_bmatch test/generated.match test/generated.log test/generated.err test/generated.out bin/germline bin/impute_to_ped
+

--- a/MatchesBuilder.h
+++ b/MatchesBuilder.h
@@ -1,7 +1,7 @@
 // MatchesBuilder.h: builds matches from individuals
 
 #ifndef MATCHESBUILDER_H
-#define MATCHESBUILDERs_H
+#define MATCHESBUILDER_H
 
 #include "BasicDefinitions.h"
 #include "Individuals.h"
@@ -44,8 +44,8 @@ private:
 	// matchMarkerSet(): builds matches for individuals considering markers in marker set.
 	// Precondition: individualsP points to a valid Individuals object and matchesP
 	//  points to a valid Matches object.
-	// Postcondition: matchesP points to a valid Matches object containing all 
-	//   matches for individuals considering markers in marker set markerSetPosition, 
+	// Postcondition: matchesP points to a valid Matches object containing all
+	//   matches for individuals considering markers in marker set markerSetPosition,
 	//   extending existing matches whenever possible.
 	void matchMarkerSet();
 	void readMarkerSet();
@@ -59,8 +59,8 @@ private:
 	PolymorphicIndividualsExtractor* pieP;
 
 	unsigned int ms_start, ms_end;
-}; 
+};
 
-#endif 
+#endif
 
 // end MatchesBuilder.h

--- a/PolymorphicIndividualsExtractor.cpp
+++ b/PolymorphicIndividualsExtractor.cpp
@@ -1,4 +1,4 @@
-// PolymorphicIndividualsExtractor.cpp: Abstract base class to extract individuals 
+// PolymorphicIndividualsExtractor.cpp: Abstract base class to extract individuals
 //   from various file formats
 
 #include "PolymorphicIndividualsExtractor.h"
@@ -12,6 +12,9 @@ using namespace std;
 PolymorphicIndividualsExtractor::PolymorphicIndividualsExtractor()
 : individualsP(NULL), valid_flag(true)
 {}
+
+PolymorphicIndividualsExtractor::~PolymorphicIndividualsExtractor() {
+}
 
 void PolymorphicIndividualsExtractor::setPhased(bool p)
 {

--- a/PolymorphicIndividualsExtractor.h
+++ b/PolymorphicIndividualsExtractor.h
@@ -1,4 +1,4 @@
-// PolymorphicIndividualsExtractor.h: Abstract base class to extract individuals 
+// PolymorphicIndividualsExtractor.h: Abstract base class to extract individuals
 //   from various file formats
 
 #ifndef POLYMORPHICINDIVIDUALSEXTRACTOR_H
@@ -17,7 +17,7 @@ public:
 
 	// PolymorphicIndividualsExtractor(): default constructor
 	// Precondition: None.
-	// Postcondition: individualsP has been set to NULL, 
+	// Postcondition: individualsP has been set to NULL,
 	//  numberOfMarkers has been set to 0, and names for
 	//  CSV files and INFO file have been been obtained from
 	//  user.
@@ -25,6 +25,8 @@ public:
 	//  would be a delay before prompting for the input file
 	//  which depends on the derived class for validation.
 	PolymorphicIndividualsExtractor();
+
+	virtual ~PolymorphicIndividualsExtractor();
 
 	// getInput(): virtual function to extract input
 	// Precondition: None.

--- a/impute_to_ped.cpp
+++ b/impute_to_ped.cpp
@@ -9,12 +9,12 @@
 
 using namespace std;
 
-int main (int argc, char* argv[]) 
+int main (int argc, char* argv[])
 {
 	string line, discard;
 	if(argc < 3){
 		cerr << "Usage: " << argv[0] << " <haps file> <sample file> <output>" << endl;
-		return 0;
+		return 1;
 	}
 	ifstream file_haps(argv[1]);
 	ifstream file_samp(argv[2]);
@@ -37,10 +37,10 @@ int main (int argc, char* argv[])
 		fam.push_back( map_field[0] + " " + map_field[1] + " 0 0 0 0" );
 	}
 	file_samp.close();
-	
+
 	string * seq = new string[ fam.size() ];
 	cout << fam.size() << " samples" << endl;
-	
+
 	// read all data
 	int snp_ctr = 0;
 	char al[2] , inp;
@@ -61,7 +61,7 @@ int main (int argc, char* argv[])
 			cur_al = string( 1 , al[ inp - '0' ] );
 			if(snp_ctr == 0) seq[i] = cur_al;
 			else seq[i] += " " + cur_al;
-			
+
 			ss >> inp;
 			cur_al = string( 1 , al[ inp - '0' ] );
 			seq[i] += " " + cur_al;
@@ -70,10 +70,9 @@ int main (int argc, char* argv[])
 	}
 	file_haps.close();
 	file_map.close();
-	
+
 	// print all markers
-	int id = 0;
-	for(int i=0;i< fam.size() ;i++) file_ped << fam[i] << " " << seq[i] << endl;
+	for (int i = 0; i < fam.size(); i++) file_ped << fam[i] << " " << seq[i] << endl;
 	file_ped.close();
-	return 1;
+	return 0;
 }


### PR DESCRIPTION
- `impute_to_ped` and `germline` have their respective main functions `return 0` on bad input arguments, but they `return 1` on success. Switching those return values resolves the issue of weird exit codes.

- Memory leak was addressed as follows: 
    1.  Declaration of a virtual destructor in the `PolymorphicIndividualsExtractor` class
    2. Defined a destructor in `PolymorphicIndividualsExtractor.cpp`

- Fixed a typo in the #include guard in `MatchesBuilder.h`

- Now using a `make` implicit rule to generate object files and added a rule to compile `impute_to_ped.cpp` and output it to the `bin` directory in the case that a user wishes to compile germline prior to using it.

Note: the precompiled binaries in currently located in `bin/germline` will have to be re-compiled to reflect these latest changes.
All tests were run in a container running Ubuntu 18.04